### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # app-dev
 My first repository
+
+**Uncle Drew**
+
+*An anti-ageist comedy about a man's dream to win the Rucker Classic street ball tournament in Harlem.*
+
+*It stars Kyrie Irving as the title character from his Pepsi Max advertisements that began airing in 2012, along with former NBA players Shaquille O'Neal, Chris Webber, Reggie Miller, and Nate Robinson, as well as former WNBA player Lisa Leslie. Lil Rel Howery, Erica Ash, J. B. Smoove, Mike Epps, Tiffany Haddish, and Nick Kroll also star.*


### PR DESCRIPTION
Kyrie Irving created the character of Uncle Drew for Pepsi Max advertisements that first aired in 2012. He says that he got the idea for the Uncle Drew character after watching a YouTube video where an old man shows off at a skate park.

@sti-admin